### PR TITLE
ci: drop support for go 1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: go
 go:
-  - 1.12
   - 1.13
-install: true
 script:
   - make build test


### PR DESCRIPTION
Drop support for go 1.12, the context support used in `net/http` was added in go 1.13:

https://golang.org/doc/go1.13#net/http