### PR TITLE
Dockerfile - use newer golang

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8 as builder
+FROM golang:1.19.3 as builder
 
 WORKDIR /go/src/github.com/jahkeup/updater53
 COPY . .


### PR DESCRIPTION
The current Dockerfile fails to build, giving the error below.
Bumping `golang` version fixes the issue.

Before:

```
[..]
Step 7/15 : RUN go get -d -v ./...                                                                      ---> Running in fa8d8ab50797                                                                          github.com/aws/aws-sdk-go (download)
github.com/jmespath/go-jmespath (download)
github.com/cenkalti/backoff (download)
github.com/miekg/dns (download)
package crypto/ed25519: unrecognized import path "crypto/ed25519" (import path does not begin with hostname)
Fetching https://golang.org/x/net/ipv4?go-get=1
Parsing meta tags from https://golang.org/x/net/ipv4?go-get=1 (status code 200)
get "golang.org/x/net/ipv4": found meta tag main.metaImport{Prefix:"golang.org/x/net", VCS:"git", RepoRoot:"https://go.googlesource.com/net"} at https://golang.org/x/net/ipv4?go-get=1
get "golang.org/x/net/ipv4": verifying non-authoritative meta tag
Fetching https://golang.org/x/net?go-get=1
Parsing meta tags from https://golang.org/x/net?go-get=1 (status code 200)
golang.org/x/net (download)
Fetching https://golang.org/x/sys/unix?go-get=1
Parsing meta tags from https://golang.org/x/sys/unix?go-get=1 (status code 200)
get "golang.org/x/sys/unix": found meta tag main.metaImport{Prefix:"golang.org/x/sys", VCS:"git", RepoRoot:"https://go.googlesource.com/sys"} at https://golang.org/x/sys/unix?go-get=1
get "golang.org/x/sys/unix": verifying non-authoritative meta tag
Fetching https://golang.org/x/sys?go-get=1
Parsing meta tags from https://golang.org/x/sys?go-get=1 (status code 200)
golang.org/x/sys (download)
package math/bits: unrecognized import path "math/bits" (import path does not begin with hostname)
Fetching https://golang.org/x/net/ipv6?go-get=1
Parsing meta tags from https://golang.org/x/net/ipv6?go-get=1 (status code 200)
get "golang.org/x/net/ipv6": found meta tag main.metaImport{Prefix:"golang.org/x/net", VCS:"git", RepoRoot:"https://go.googlesource.com/net"} at https://golang.org/x/net/ipv6?go-get=1
get "golang.org/x/net/ipv6": verifying non-authoritative meta tag
github.com/pkg/errors (download)
The command '/bin/sh -c go get -d -v ./...' returned a non-zero code: 1
```

After:

```
[..]
Step 14/15 : COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 ---> bcd06ef7ee62
Step 15/15 : ENTRYPOINT ["/usr/bin/updater53"]
 ---> Running in 8b70c15e6bd0
Removing intermediate container 8b70c15e6bd0
 ---> 04a5ffeb70d2
Successfully built 04a5ffeb70d2
```